### PR TITLE
改进检验参数

### DIFF
--- a/docs/cn/actions/service/send-to-flomo.json
+++ b/docs/cn/actions/service/send-to-flomo.json
@@ -206,7 +206,7 @@
       "type" : "@flow.if",
       "parameters" : {
         "blockIdentifier" : "A353CE67-C62F-40FD-9619-FE480E9B9FC1",
-        "condition" : 0,
+        "condition" : 3,
         "rhs" : {
           "value" : "{\"code\":0,\"message\":\"\\u5df2\\u8bb0\\u5f55\""
         },

--- a/docs/cn/actions/service/send-to-flomo.json
+++ b/docs/cn/actions/service/send-to-flomo.json
@@ -208,7 +208,7 @@
         "blockIdentifier" : "A353CE67-C62F-40FD-9619-FE480E9B9FC1",
         "condition" : 0,
         "rhs" : {
-          "value" : "{\"code\":0,\"message\":\"\\u8bb0\\u5f55\\u6210\\u529f\"}"
+          "value" : "{\"code\":0,\"message\":\"\\u5df2\\u8bb0\\u5f55\""
         },
         "lhs" : {
           "value" : "$",


### PR DESCRIPTION
flomo创建很长时间都是提示失败，网页观察实际成功。
观察反馈信息，猜测服务端更改了请求回应参数，新回应开头为：
```{"code":0,"message":"\u5df2\u8bb0\u5f55"```
我个人替换了一下成功了，但是我不懂编程，如方便，请帮忙测试并更新，非常感谢。